### PR TITLE
Add command line flag to fetch full or androidlowmem CRLSet

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,12 @@ First you need to download the current CRL set:
     % ./crlset fetch > crl-set
     Downloading CRLSet version 59
 
+By default this fetches the full CRL set, but if you want to instead fetch the
+lighter-weight CRL set intended for low-memory devices, you can instead run:
+
+    % ./crlset fetch -androidlowmem > crl-set
+    Downloading CRLSet version 59
+
 Then you can dump the contents of the CRL set:
 
     % ./crlset dump crl-set

--- a/crlset.go
+++ b/crlset.go
@@ -29,10 +29,12 @@ import (
 // update and the related structures are used for parsing the XML response from Omaha. The response looks like:
 // <?xml version="1.0" encoding="UTF-8"?>
 // <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0" server="prod">
-//   <daystart elapsed_seconds="42913"/>
-//   <app appid="hfnkpimlhhgieaddgfemjhofmfblmnib" status="ok">
-//     <updatecheck codebase="http://www.gstatic.com/chrome/crlset/56/crl-set-14830555124393087472.crx.data" hash="" size="0" status="ok" version="56"/>
-//   </app>
+//
+//	<daystart elapsed_seconds="42913"/>
+//	<app appid="hfnkpimlhhgieaddgfemjhofmfblmnib" status="ok">
+//	  <updatecheck codebase="http://www.gstatic.com/chrome/crlset/56/crl-set-14830555124393087472.crx.data" hash="" size="0" status="ok" version="56"/>
+//	</app>
+//
 // </gupdate>
 type update struct {
 	XMLName xml.Name    `xml:"gupdate"`
@@ -56,9 +58,17 @@ const crlSetAppId = "hfnkpimlhhgieaddgfemjhofmfblmnib"
 
 // buildVersionRequestURL returns a URL from which the current CRLSet version
 // information can be fetched.
-func buildVersionRequestURL() string {
+func buildVersionRequestURL(full bool) string {
+	arg := fmt.Sprintf("id=%s&v=&uc&acceptformat=crx3", crlSetAppId)
+	if full {
+		// This causes omaha to bucket the request into the "Auto full" cohort,
+		// rather than the "Auto androidlowmem" (default) bucket. The full cohort
+		// gets a much larger crlset than the androidlowmem cohort.
+		arg = arg + "&updaterversion=127"
+	}
+
 	args := url.Values(make(map[string][]string))
-	args.Add("x", "id="+crlSetAppId+"&v=&uc"+"&acceptformat=crx3")
+	args.Add("x", arg)
 
 	return (&url.URL{
 		Scheme:   "https",
@@ -85,8 +95,8 @@ func (z zipReader) ReadAt(p []byte, pos int64) (int, error) {
 	return copy(p, []byte(z)[int(pos):]), nil
 }
 
-func fetch() bool {
-	resp, err := http.Get(buildVersionRequestURL())
+func fetch(full bool) bool {
+	resp, err := http.Get(buildVersionRequestURL(full))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get current version: %s\n", err)
 		return false
@@ -343,7 +353,7 @@ func getHeader(filename string) (header crlSetHeader, rest []byte, ok bool) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "%s: { fetch | dumpSPKIs <filename> | dump <filename> [<cert filename>] }\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "%s: { fetch [-androidlowmem] | dumpSPKIs <filename> | dump <filename> [<cert filename>] }\n", os.Args[0])
 }
 
 func main() {
@@ -358,7 +368,10 @@ func main() {
 	switch os.Args[1] {
 	case "fetch":
 		if len(os.Args) == 2 {
-			result = fetch()
+			result = fetch(true)
+			needUsage = false
+		} else if len(os.Args) == 3 && os.Args[2] == "-androidlowmem" {
+			result = fetch(false)
 			needUsage = false
 		}
 	case "dump":

--- a/crlset.go
+++ b/crlset.go
@@ -29,12 +29,10 @@ import (
 // update and the related structures are used for parsing the XML response from Omaha. The response looks like:
 // <?xml version="1.0" encoding="UTF-8"?>
 // <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0" server="prod">
-//
-//	<daystart elapsed_seconds="42913"/>
-//	<app appid="hfnkpimlhhgieaddgfemjhofmfblmnib" status="ok">
-//	  <updatecheck codebase="http://www.gstatic.com/chrome/crlset/56/crl-set-14830555124393087472.crx.data" hash="" size="0" status="ok" version="56"/>
-//	</app>
-//
+//   <daystart elapsed_seconds="42913"/>
+//   <app appid="hfnkpimlhhgieaddgfemjhofmfblmnib" status="ok">
+//     <updatecheck codebase="http://www.gstatic.com/chrome/crlset/56/crl-set-14830555124393087472.crx.data" hash="" size="0" status="ok" version="56"/>
+//   </app>
 // </gupdate>
 type update struct {
 	XMLName xml.Name    `xml:"gupdate"`

--- a/crlset.go
+++ b/crlset.go
@@ -59,16 +59,14 @@ const crlSetAppId = "hfnkpimlhhgieaddgfemjhofmfblmnib"
 // buildVersionRequestURL returns a URL from which the current CRLSet version
 // information can be fetched.
 func buildVersionRequestURL(full bool) string {
-	arg := fmt.Sprintf("id=%s&v=&uc&acceptformat=crx3", crlSetAppId)
+	args := url.Values(make(map[string][]string))
+	args.Add("x", "id="+crlSetAppId+"&v=&uc"+"&acceptformat=crx3")
 	if full {
 		// This causes omaha to bucket the request into the "Auto full" cohort,
 		// rather than the "Auto androidlowmem" (default) bucket. The full cohort
 		// gets a much larger crlset than the androidlowmem cohort.
-		arg = arg + "&updaterversion=127"
+		args.Add("tag", "force_full")
 	}
-
-	args := url.Values(make(map[string][]string))
-	args.Add("x", arg)
 
 	return (&url.URL{
 		Scheme:   "https",


### PR DESCRIPTION
Add `tag=force_full` to the Omaha URL that the `fetch` subcommand uses to check for the latest CRLSet. This causes Omaha to bucket this client into the "Auto full" cohort, and to provide the URL to the full-size CRLSet containing revocations from all CRLs disclosed in CCADB.

Add a `-androidlowmem` flag to the `fetch` subcommand. When this flag is passed, do not append the new query parameter to the Omaha URL. This causes Omaha to bucket this client into the "Auto androidlowmem" cohort, and to provide the URL to a stripped-down CRLSet containing only high-priority revocations.

Example usage:
```shell
$ go run ./crlset.go fetch > full.crlset                                                        
Downloading CRLSet version 9982

$ go run ./crlset.go fetch -androidlowmem > alm.crlset                                           
Downloading CRLSet version 9982

$ du -sh *.crlset
24K		alm.crlset
612K	full.crlset

$ go run ./crlset.go dump alm.crlset letsencrypt-int-r10.pem | wc -l 
0

$ go run ./crlset.go dump full.crlset letsencrypt-int-r10.pem | wc -l
5345
```